### PR TITLE
Fix Installs on Pre 060

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,8 +10,7 @@ readme = "README.md"
 requires-python = ">= 3.8.1"
 dependencies = [
     "guardrails-ai>=0.4.0",
-    "litellm",
-    "guardrails-grhub-response_evaluator<1.0.0"
+    "litellm"
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
- Removed private pypi dependency in `main` branch until CI monkeypatches pyproject to include validator only for pypi version